### PR TITLE
Static server

### DIFF
--- a/ui/server/database.js
+++ b/ui/server/database.js
@@ -1,5 +1,35 @@
 module.exports = {
-    scopes: [{
-
-    }]
+    scopes: [
+        {
+            code: 'MOVIES',
+            label: 'Films',
+            active: true
+        },
+        {
+            code: 'PEOPLE',
+            label: 'Personnes',
+            active: true
+        }
+    ],
+    movies: [
+        {
+            'movId': 985154,
+            'title': 'Le groupe',
+            'released': '2001-09-12T00:00:00.000Z',
+            'year': 2001,
+            'metadasJson': '\'Le groupe\' (2001) {Conspiration (#1.12)}'
+        }
+        // TODO : fill in more data
+    ],
+    movieDetails: [
+        {
+            'movId': 985154,
+            'title': 'Le groupe',
+            'released': '2001-09-12T00:00:00.000Z',
+            'genreIds': 'Comedy|Drama|Romance',
+            'countryIds': 'France',
+            'languageIds': 'French'
+        }
+        // TODO : fill in more data
+    ]
 };

--- a/ui/server/database.js
+++ b/ui/server/database.js
@@ -1,0 +1,5 @@
+module.exports = {
+    scopes: [{
+
+    }]
+};

--- a/ui/server/package.json
+++ b/ui/server/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.12.4",
     "express": "^4.12.4",
     "lodash": "^3.9.3"
   }

--- a/ui/server/package.json
+++ b/ui/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "json-server": "^0.7.9"
+    "express": "^4.12.4",
+    "lodash": "^3.9.3"
   }
 }

--- a/ui/server/server.js
+++ b/ui/server/server.js
@@ -1,0 +1,26 @@
+var express = require('express');
+var _ = require('lodash');
+
+var database = require('./database');
+
+var staticFolder = '../../api/src/main/webapp/static';
+
+var app = express();
+app.use(express.static(staticFolder));
+
+// Common
+
+// Masterdata
+app.get('/scopes', function(req, res) {
+    res.json(database.scopes);
+});
+
+// Movie
+
+// People
+
+
+var server = app.listen(8081, function() {
+    var port = server.address().port;
+    console.log('Mocked API listening at http://localhost:%s', port);
+});

--- a/ui/server/server.js
+++ b/ui/server/server.js
@@ -1,10 +1,17 @@
+#!/usr/bin/env node
+
 var express = require('express');
 var _ = require('lodash');
 var bodyParser = require('body-parser')
 
 var database = require('./database');
 
-var staticFolder = '../../api/src/main/webapp/static';
+var args = process.argv.slice(2);
+var baseDir = './';
+if (args.length > 0) {
+    baseDir = args[0];
+}
+var staticFolder = baseDir + '../../api/src/main/webapp/static';
 
 var app = express();
 app.use(express.static(staticFolder));
@@ -12,6 +19,13 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
     extended: true
 }));
+app.use(function(req, res, next) {
+    console.log(new Date() + ', ' + req.method + ', ' + req.url);
+    if (!_.isEmpty(req.body)) {
+        console.log(req.body);
+    }
+    next();
+});
 
 // Common
 app.post('/searchByScope', function(req, res) {

--- a/ui/server/server.js
+++ b/ui/server/server.js
@@ -30,10 +30,18 @@ app.use(function(req, res, next) {
 // Common
 app.post('/searchByScope', function(req, res) {
     var criteria = req.body.criteria;
+    var pageInfos = req.body.pageInfos;
     var facets = req.body.facets;
-    var clusteringFaacetName = req.body.group;
-    console.log(criteria);
-    req.json([]);
+    var clusteringFacetName = req.body.group;
+
+    var movies = _.filter(database.movies, function(movie) {
+        return movie.title.search(new RegExp('.*' + criteria.query + '.*')) !== -1;
+    });
+    res.json({
+        list: movies,
+        facets: [],
+        totalRecords: movies.length
+    });
 });
 
 // Masterdata
@@ -42,6 +50,12 @@ app.get('/scopes', function(req, res) {
 });
 
 // Movie
+
+app.get('/movies/:movId/details', function(req, res) {
+    res.json(_.find(database.movieDetails, function(details) {
+        return details.movId == req.param('movId');
+    }));
+});
 
 // People
 

--- a/ui/server/server.js
+++ b/ui/server/server.js
@@ -1,5 +1,6 @@
 var express = require('express');
 var _ = require('lodash');
+var bodyParser = require('body-parser')
 
 var database = require('./database');
 
@@ -7,8 +8,19 @@ var staticFolder = '../../api/src/main/webapp/static';
 
 var app = express();
 app.use(express.static(staticFolder));
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({
+    extended: true
+}));
 
 // Common
+app.post('/searchByScope', function(req, res) {
+    var criteria = req.body.criteria;
+    var facets = req.body.facets;
+    var clusteringFaacetName = req.body.group;
+    console.log(criteria);
+    req.json([]);
+});
 
 // Masterdata
 app.get('/scopes', function(req, res) {

--- a/ui/standalone.js
+++ b/ui/standalone.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 var childProcess = require('child_process')
 
 console.log('###########################################');
@@ -11,7 +13,7 @@ console.log();
 
 var brunch = childProcess.exec('brunch watch');
 
-var server = childProcess.exec('node server/server.js');
+var server = childProcess.exec('node server/server.js server/');
 
 brunch.stdout.pipe(process.stdout);
 brunch.stderr.pipe(process.stderr);

--- a/ui/standalone.js
+++ b/ui/standalone.js
@@ -1,0 +1,19 @@
+var childProcess = require('child_process')
+
+console.log('###########################################');
+console.log('######### Focus demo standalone api #######');
+console.log('###########################################');
+console.log('# Work on your UI code, change will be    #');
+console.log('# taken into account and served           #');
+console.log('# localhost port 8081.                    #');
+console.log('###########################################');
+console.log();
+
+var brunch = childProcess.exec('brunch watch');
+
+var server = childProcess.exec('node server/server.js');
+
+brunch.stdout.pipe(process.stdout);
+brunch.stderr.pipe(process.stderr);
+server.stdout.pipe(process.stdout);
+brunch.stderr.pipe(process.stderr);


### PR DESCRIPTION
Standalone server, used to avoir running the heavy java backend, for fast front development.
Database is still poor, it needs to be filled in, and not all web services are mocked yet.
To launch it, just run `node standalone.js` in the `ui` folder.